### PR TITLE
Fixes performance in Firefox by converting NativeImage to Bitmap32

### DIFF
--- a/src/commonMain/kotlin/com/github/servb/pph/pheroes/Game/Credits.kt
+++ b/src/commonMain/kotlin/com/github/servb/pph/pheroes/Game/Credits.kt
@@ -76,7 +76,7 @@ class iCreditsComposer {
 
     suspend fun Init() {
         m_back.Init(ISizeInt(320, 720), IiDib.Type.RGB)
-        resourcesVfs["pheroes/bin/Resources/hmm/GFX/Pix/MenuBack.png"].readBitmap().copyTo(m_back)
+        resourcesVfs["pheroes/bin/Resources/hmm/GFX/Pix/MenuBack.png"].readBitmap().toBMP32().copyTo(m_back)
 
         m_logo = resourcesVfs[selectLogoPath()].readBitmap().toBMP32()
 

--- a/src/commonMain/kotlin/com/github/servb/pph/pheroes/Game/TextComposer.kt
+++ b/src/commonMain/kotlin/com/github/servb/pph/pheroes/Game/TextComposer.kt
@@ -103,7 +103,7 @@ class iTextComposer {
 
         repeat(FontSize.COUNT.v) { nn ->
             val resourcePath = FontSize.values().first { it.v == nn }.resourcePath
-            val bmp = resourcesVfs[resourcePath].readBitmap()
+            val bmp = resourcesVfs[resourcePath].readBitmap().toBMP32()
             val next = iDibFont()
             if (!next.Init(bmp, if (nn == 2) 2 else 0)) {
                 return false


### PR DESCRIPTION
This is because reading and writing pixels into a canvas might be a costly operation
depending on the JS-Canvas implementation.